### PR TITLE
re-add the flutter sdk version requirement

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ repository: https://github.com/MindscapeHQ/Raygun4Flutter
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Version 0.1.0 has been published, however to do so I had to add again the flutter SDK version requirement, which was removed in https://github.com/MindscapeHQ/raygun4flutter/pull/4