### PR TITLE
First batch of plugin changes targetting Android (for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `tags` and `customData` to the error sending methods.
 * Error sending methods can generate a stacktrace automatically.
 * Added `setUser()` method with `RaygunUserInfo`.
+* Added `setVersion()` method.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## xxx
+
+* Change `init()` signature to named parameters and added optional `version`.
+
 ## 0.1.0
 
 * Null safety migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## xxx
 
 * Change `init()` signature to named parameters and added optional `version`.
+* Added `setTags()` and `setCustomData()` methods.
+* Added `tags` and `customData` to the error sending methods.
+* Error sending methods can generate a stacktrace automatically.
+* Added `setUser()` method with `RaygunUserInfo`.
 
 ## 0.1.0
 

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -27,7 +27,10 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         context = flutterPluginBinding.applicationContext
-        channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "com.raygun.raygun4flutter/raygun4flutter")
+        channel = MethodChannel(
+            flutterPluginBinding.getFlutterEngine().getDartExecutor(),
+            "com.raygun.raygun4flutter/raygun4flutter"
+        )
         channel.setMethodCallHandler(this);
     }
 
@@ -70,21 +73,16 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
         val className = methodCall.argument<String>("className")
         val reason = methodCall.argument<String>("reason")
         val flutterStackTrace = methodCall.argument<String>("stackTrace")
+        val tags = methodCall.argument<List<*>>("tags")
+        val customData = methodCall.argument<Map<*, *>>("customData")
         RaygunClient.send(
-                FlutterException(
-                        message = reason,
-                        flutterStackTrace = flutterStackTrace,
-                        className = className
-                ),
-                listOf(
-                        "Android",
-                        "Flutter"
-                ),
-                mapOf(
-                        "className" to className,
-                        "reason" to reason,
-                        "stackTrace" to flutterStackTrace
-                )
+            FlutterException(
+                message = reason,
+                flutterStackTrace = flutterStackTrace,
+                className = className
+            ),
+            tags,
+            customData
         )
     }
 
@@ -103,9 +101,9 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
 }
 
 class FlutterException(
-        val className: String?,
-        override val message: String?,
-        flutterStackTrace: String?
+    val className: String?,
+    override val message: String?,
+    flutterStackTrace: String?
 ) : Throwable(message = message) {
 
     init {
@@ -115,17 +113,17 @@ class FlutterException(
                 val parts = it.split("#")
                 if (parts.size == 2) {
                     StackTraceElement(
-                            parts[0],
-                            "",
-                            parts[1], // Already contains fileName and line:column
-                            0
+                        parts[0],
+                        "",
+                        parts[1], // Already contains fileName and line:column
+                        0
                     )
                 } else {
                     StackTraceElement(
-                            "",
-                            "",
-                            it, // Already contains fileName and line:column
-                            0
+                        "",
+                        "",
+                        it, // Already contains fileName and line:column
+                        0
                     )
                 }
             }.toTypedArray()

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -38,9 +38,9 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
         when (methodCall.method) {
             "init" -> onInit(methodCall)
             "send" -> onSend(methodCall)
-            "breadcrumb" -> onBreadcrumb(methodCall)
+            "recordBreadcrumb" -> onBreadcrumb(methodCall)
             "setUserId" -> onUserId(methodCall)
-            "user" -> onUser(methodCall)
+            "setUser" -> onUser(methodCall)
             "setTags" -> onSetTags(methodCall)
             "setCustomData" -> onSetCustomData(methodCall)
             "setVersion" -> onVersion(methodCall)

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -43,9 +43,15 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
             "user" -> onUser(methodCall)
             "setTags" -> onSetTags(methodCall)
             "setCustomData" -> onSetCustomData(methodCall)
+            "version" -> onVersion(methodCall)
             else -> result.notImplemented()
         }
         result.success(null)
+    }
+
+    private fun onVersion(methodCall: MethodCall) {
+        val version = methodCall.argument<String?>("version")
+        RaygunClient.setVersion(version)
     }
 
     private fun onUser(methodCall: MethodCall) {

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -40,11 +40,21 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
             "send" -> onSend(methodCall)
             "breadcrumb" -> onBreadcrumb(methodCall)
             "userId" -> onUserId(methodCall)
+            "user" -> onUser(methodCall)
             "setTags" -> onSetTags(methodCall)
             "setCustomData" -> onSetCustomData(methodCall)
             else -> result.notImplemented()
         }
         result.success(null)
+    }
+
+    private fun onUser(methodCall: MethodCall) {
+        val identifier = methodCall.argument<String?>("identifier")
+        val email = methodCall.argument<String?>("email")
+        val firstName = methodCall.argument<String?>("firstName")
+        val fullName = methodCall.argument<String?>("fullName")
+        val info = RaygunUserInfo(identifier, firstName, fullName, email);
+        RaygunClient.setUser(info)
     }
 
     private fun onSetCustomData(methodCall: MethodCall) {

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -43,7 +43,7 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
             "user" -> onUser(methodCall)
             "setTags" -> onSetTags(methodCall)
             "setCustomData" -> onSetCustomData(methodCall)
-            "version" -> onVersion(methodCall)
+            "setVersion" -> onVersion(methodCall)
             else -> result.notImplemented()
         }
         result.success(null)

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -44,7 +44,8 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
 
     private fun onInit(methodCall: MethodCall) {
         val apiKey = methodCall.argument<String>("apiKey")
-        RaygunClient.init(context as Application, apiKey)
+        val version = methodCall.argument<String?>("version")
+        RaygunClient.init(context as Application, apiKey, version)
         RaygunClient.enableCrashReporting()
     }
 

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -37,9 +37,21 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
             "send" -> onSend(methodCall)
             "breadcrumb" -> onBreadcrumb(methodCall)
             "userId" -> onUserId(methodCall)
+            "setTags" -> onSetTags(methodCall)
+            "setCustomData" -> onSetCustomData(methodCall)
             else -> result.notImplemented()
         }
         result.success(null)
+    }
+
+    private fun onSetCustomData(methodCall: MethodCall) {
+        val customData = methodCall.arguments as Map<*, *>?
+        RaygunClient.setCustomData(customData)
+    }
+
+    private fun onSetTags(methodCall: MethodCall) {
+        val tags = methodCall.arguments as List<*>?
+        RaygunClient.setTags(tags)
     }
 
     private fun onInit(methodCall: MethodCall) {

--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -39,7 +39,7 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
             "init" -> onInit(methodCall)
             "send" -> onSend(methodCall)
             "breadcrumb" -> onBreadcrumb(methodCall)
-            "userId" -> onUserId(methodCall)
+            "setUserId" -> onUserId(methodCall)
             "user" -> onUser(methodCall)
             "setTags" -> onSetTags(methodCall)
             "setCustomData" -> onSetCustomData(methodCall)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -108,7 +108,7 @@ class _MyAppState extends State<MyApp> {
             ),
             ElevatedButton(
               onPressed: () {
-                Raygun.breadcrumb('test breadcrumb');
+                Raygun.recordBreadcrumb('test breadcrumb');
               },
               child: const Text('Breadcrumb'),
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,8 +14,8 @@ void main() {
 
     // Raygun error handling
     Raygun.sendException(
-      details.exception,
-      details.stack,
+      error: details.exception,
+      stackTrace: details.stack,
     );
   };
 
@@ -23,7 +23,10 @@ void main() {
   runZonedGuarded<Future<void>>(() async {
     runApp(const MyApp());
   }, (Object error, StackTrace stackTrace) {
-    Raygun.sendException(error, stackTrace);
+    Raygun.sendException(
+      error: error,
+      stackTrace: stackTrace,
+    );
   });
 }
 
@@ -73,12 +76,35 @@ class _MyAppState extends State<MyApp> {
             ElevatedButton(
               onPressed: () {
                 Raygun.sendCustom(
-                  'MyApp',
-                  'test error message',
-                  StackTrace.current,
+                  className: 'MyApp',
+                  reason: 'test error message',
                 );
               },
               child: const Text('Send custom error'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Raygun.sendCustom(
+                  className: 'MyApp',
+                  reason: 'test error message',
+                  stackTrace: StackTrace.current,
+                );
+              },
+              child: const Text('Send custom error with StackTrace'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Raygun.sendCustom(
+                  className: 'MyApp',
+                  reason: 'test error message',
+                  tags: ['myTag1', 'myTag2'],
+                  customData: {
+                    'custom1': 'value',
+                    'custom2': 42,
+                  },
+                );
+              },
+              child: const Text('Send custom error with tags and customData'),
             ),
             ElevatedButton(
               onPressed: () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -118,6 +118,19 @@ class _MyAppState extends State<MyApp> {
               },
               child: const Text('User Id'),
             ),
+            ElevatedButton(
+              onPressed: () {
+                Raygun.setUser(
+                  RaygunUserInfo(
+                    identifier: '1234',
+                    firstName: 'FIRST',
+                    fullName: 'FIRST LAST',
+                    email: 'test@example.com',
+                  ),
+                );
+              },
+              child: const Text('Set RaygunUserInfo'),
+            ),
           ],
         ),
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -158,3 +158,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: raygun4flutter_example
 description: Demonstrates how to use the raygun4flutter plugin.
+version: 0.0.1+1
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -128,7 +128,7 @@ class Raygun {
   }
 
   /// Sends a breadcrumb to Raygun
-  static Future<void> breadcrumb(String message) async {
+  static Future<void> recordBreadcrumb(String message) async {
     await channel.invokeMethod('breadcrumb', <String, String>{
       'message': message,
     });

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -129,7 +129,7 @@ class Raygun {
 
   /// Sends a breadcrumb to Raygun
   static Future<void> recordBreadcrumb(String message) async {
-    await channel.invokeMethod('breadcrumb', <String, String>{
+    await channel.invokeMethod('recordBreadcrumb', <String, String>{
       'message': message,
     });
   }
@@ -165,6 +165,6 @@ class Raygun {
   ///
   /// Set to null to clear
   static Future<void> setUser(RaygunUserInfo? raygunUserInfo) async {
-    await channel.invokeMethod('user', raygunUserInfo?.toMap());
+    await channel.invokeMethod('setUser', raygunUserInfo?.toMap());
   }
 }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -13,9 +13,16 @@ class Raygun {
   static const channel =
       MethodChannel('com.raygun.raygun4flutter/raygun4flutter');
 
-  static Future init(String apiKey) async {
-    await channel.invokeMethod('init', <String, String>{
+  /// Initalizes the Raygun client with your Raygun API [apiKey].
+  /// [version] is optional, if not provided it will be obtained from your
+  /// pubspec.yaml.
+  static Future init({
+    required String apiKey,
+    String? version,
+  }) async {
+    await channel.invokeMethod('init', <String, dynamic>{
       'apiKey': apiKey,
+      'version': version,
     });
   }
 

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -40,7 +40,7 @@ class Raygun {
   static Future<void> setVersion(
     String? version,
   ) async {
-    await channel.invokeMethod('version', <String, dynamic>{
+    await channel.invokeMethod('setVersion', <String, dynamic>{
       'version': version,
     });
   }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -14,6 +14,7 @@ class Raygun {
       MethodChannel('com.raygun.raygun4flutter/raygun4flutter');
 
   /// Initalizes the Raygun client with your Raygun API [apiKey].
+  ///
   /// [version] is optional, if not provided it will be obtained from your
   /// pubspec.yaml.
   static Future init({
@@ -27,6 +28,7 @@ class Raygun {
   }
 
   /// Sends an exception to Raygun.
+  /// Convenience method that wraps [sendCustom].
   static Future sendException(
     Object error, [
     StackTrace? stackTrace,
@@ -59,6 +61,22 @@ class Raygun {
     });
   }
 
+  /// Sets a List of tags which will be sent along with every exception.
+  /// This will be merged with any other tags passed in [sendException] and [sendCustom].
+  ///
+  /// Set to null to clear the value.
+  static Future<void> setTags(List<String>? tags) async {
+    await channel.invokeMethod('setTags', tags);
+  }
+
+  /// Sets a key-value Map which, like the tags, will be sent along with every exception.
+  /// This will be merged with any other custom data passed in [sendException] and [sendCustom].
+  ///
+  /// Set to null to clear the value.
+  static Future<void> setCustomData(Map<String, dynamic>? tags) async {
+    await channel.invokeMethod('setCustomData', tags);
+  }
+
   /// Sends a breadcrumb to Raygun
   static Future breadcrumb(String message) async {
     await channel.invokeMethod('breadcrumb', <String, String>{
@@ -67,6 +85,7 @@ class Raygun {
   }
 
   /// Sets User Id to Raygun
+  ///
   /// Set to null to clear User Id
   static Future setUserId(String? userId) async {
     await channel.invokeMethod('userId', <String, String?>{

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -146,7 +146,7 @@ class Raygun {
   ///
   /// Set to null to clear User Id
   static Future<void> setUserId(String? userId) async {
-    await channel.invokeMethod('userId', <String, String?>{
+    await channel.invokeMethod('setUserId', <String, String?>{
       'userId': userId,
     });
   }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -2,6 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import 'src/raygun_user_info.dart';
+
+export 'src/raygun_user_info.dart';
+
 /// The official Raygun provider for Flutter.
 /// This is the main class that provides functionality for
 /// sending exceptions to the Raygun service.
@@ -73,7 +77,8 @@ class Raygun {
       traceLocations = Trace.current()
           .frames
           // skip all frames that reference to this file
-          .skipWhile((element) => element.location.contains('raygun4flutter.dart'))
+          .skipWhile(
+              (element) => element.location.contains('raygun4flutter.dart'))
           .map((frame) => '${frame.member}#${frame.location}')
           .join(';');
     } else {
@@ -115,12 +120,37 @@ class Raygun {
     });
   }
 
-  /// Sets User Id to Raygun
+  /// Sets the current user of your application.
+  ///
+  /// This is a convenience method wrapping [setUser].
+  ///
+  /// If you use an email address to identify the user, please consider using
+  /// [setUser] instead of this method as it would allow you to set the email
+  /// address into both the identifier and email fields of the crash data to be sent.
+  ///
+  /// [userId] A user name or email address representing the current user.
   ///
   /// Set to null to clear User Id
   static Future setUserId(String? userId) async {
     await channel.invokeMethod('userId', <String, String?>{
       'userId': userId,
     });
+  }
+
+  /// Sets the current user of your application.
+  ///
+  /// If user is an email address which is associated with a Gravatar,
+  /// their picture will be displayed in the error view.
+  ///
+  /// If [setUser] is not called, a random ID will be assigned.
+  ///
+  /// If the user context changes in your application (i.e log in/out), be sure
+  /// to call this again with the updated user name/email address.
+  ///
+  /// [userInfo] A [RaygunUserInfo] object containing the user data you want to send in its fields.
+  ///
+  /// Set to null to clear
+  static Future setUser(RaygunUserInfo? raygunUserInfo) async {
+    await channel.invokeMethod('user', raygunUserInfo?.toMap());
   }
 }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -21,7 +21,7 @@ class Raygun {
   ///
   /// [version] is optional, if not provided it will be obtained from your
   /// pubspec.yaml.
-  static Future init({
+  static Future<void> init({
     required String apiKey,
     String? version,
   }) async {
@@ -31,10 +31,24 @@ class Raygun {
     });
   }
 
+  /// Manually stores the version of your application to be transmitted with
+  /// each message, for version filtering. This is normally read from your
+  /// pubspec.yaml or passed in on init(); this is only provided as a convenience.
+  ///
+  /// [version] The version of your application, format x.x.x.x, where x is a
+  /// positive integer.
+  static Future<void> setVersion(
+    String? version,
+  ) async {
+    await channel.invokeMethod('version', <String, dynamic>{
+      'version': version,
+    });
+  }
+
   /// Sends an exception to Raygun.
   /// Convenience method that wraps [sendCustom].
   /// The class name and the message are obtained from the [error] object.
-  static Future sendException({
+  static Future<void> sendException({
     required Object error,
     List<String>? tags,
     Map<String, dynamic>? customData,
@@ -64,7 +78,7 @@ class Raygun {
   ///
   /// [stackTrace] optional parameter, if not provided this method will obtain
   /// the current stacktrace automatically.
-  static Future sendCustom({
+  static Future<void> sendCustom({
     required String className,
     required String reason,
     List<String>? tags,
@@ -114,7 +128,7 @@ class Raygun {
   }
 
   /// Sends a breadcrumb to Raygun
-  static Future breadcrumb(String message) async {
+  static Future<void> breadcrumb(String message) async {
     await channel.invokeMethod('breadcrumb', <String, String>{
       'message': message,
     });
@@ -131,7 +145,7 @@ class Raygun {
   /// [userId] A user name or email address representing the current user.
   ///
   /// Set to null to clear User Id
-  static Future setUserId(String? userId) async {
+  static Future<void> setUserId(String? userId) async {
     await channel.invokeMethod('userId', <String, String?>{
       'userId': userId,
     });
@@ -150,7 +164,7 @@ class Raygun {
   /// [userInfo] A [RaygunUserInfo] object containing the user data you want to send in its fields.
   ///
   /// Set to null to clear
-  static Future setUser(RaygunUserInfo? raygunUserInfo) async {
+  static Future<void> setUser(RaygunUserInfo? raygunUserInfo) async {
     await channel.invokeMethod('user', raygunUserInfo?.toMap());
   }
 }

--- a/lib/src/raygun_user_info.dart
+++ b/lib/src/raygun_user_info.dart
@@ -1,0 +1,61 @@
+class RaygunUserInfo {
+  /// Set the current user's info to be transmitted - any parameter can be null
+  /// if the data is not available or you do not wish to send it.
+  RaygunUserInfo({
+    this.identifier,
+    this.firstName,
+    this.fullName,
+    this.email,
+  });
+
+  /// The user's first name
+  final String? firstName;
+
+  /// The user's full name - if setting the first name you should set this too
+  final String? fullName;
+
+  /// User's email address
+  final String? email;
+
+  /// Unique identifier for this user.
+  ///
+  /// Set this to the internal identifier you use to look up users,
+  /// or a correlation ID for anonymous users if you have one.
+  /// It doesn't have to be unique, but we will treat any duplicated values as
+  /// the same user. If you use their email address here, pass it in as the
+  /// 'emailAddress' parameter too.
+  ///
+  /// If identifier is not set and/or null, a uuid will be assigned to this field.
+  final String? identifier;
+
+  Map<String, String?> toMap() {
+    return {
+      'email': email,
+      'fullName': fullName,
+      'firstName': firstName,
+      'identifier': identifier,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'RaygunUserInfo{email: $email, fullName: $fullName, firstName: $firstName, identifier: $identifier}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is RaygunUserInfo &&
+              runtimeType == other.runtimeType &&
+              email == other.email &&
+              fullName == other.fullName &&
+              firstName == other.firstName &&
+              identifier == other.identifier;
+
+  @override
+  int get hashCode =>
+      email.hashCode ^
+      fullName.hashCode ^
+      firstName.hashCode ^
+      identifier.hashCode;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: "direct main"
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -151,3 +151,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.0"

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -17,31 +17,70 @@ void main() {
   });
 
   test('init', () {
-    Raygun.init('KEY');
+    Raygun.init(apiKey: 'KEY');
     expect(fakeChannel.invocation, {
-      'init': {'apiKey': 'KEY'}
+      'init': {
+        'apiKey': 'KEY',
+        'version': null,
+      }
+    });
+  });
+
+  test('init with version', () {
+    Raygun.init(apiKey: 'KEY', version: 'x.y.z');
+    expect(fakeChannel.invocation, {
+      'init': {
+        'apiKey': 'KEY',
+        'version': 'x.y.z',
+      }
     });
   });
 
   test('sendException without StackTrace', () {
-    Raygun.sendException(Exception('MESSAGE'));
-    expect(fakeChannel.invocation, {
-      'send': {
-        'className': '_Exception',
-        'reason': 'Exception: MESSAGE',
-        'stackTrace': '',
-      },
-    });
-  });
-
-  test('sendException with StackTrace', () {
-    Raygun.sendException(Exception('MESSAGE'), StackTrace.current);
+    Raygun.sendException(error: Exception('MESSAGE'));
     expect(fakeChannel.invocation, {
       'send': {
         'className': '_Exception',
         'reason': 'Exception: MESSAGE',
         'stackTrace':
-            'main.<fn>#test/raygun4flutter_test.dart 38:59;Declarer.test.<fn>.<fn>#package:test_api/src/backend/declarer.dart 200:19;StackZoneSpecification._registerUnaryCallback.<fn>#package:stack_trace/src/stack_zone_specification.dart'
+            'main.<fn>#test/raygun4flutter_test.dart 40:12;Declarer.test.<fn>.<fn>#package:test_api/src/backend/declarer.dart 200:19;StackZoneSpecification._registerUnaryCallback.<fn>#package:stack_trace/src/stack_zone_specification.dart',
+        'tags': null,
+        'customData': null,
+      },
+    });
+  });
+
+  test('sendException with StackTrace', () {
+    Raygun.sendException(
+      error: Exception('MESSAGE'),
+      stackTrace: StackTrace.current,
+    );
+    expect(fakeChannel.invocation, {
+      'send': {
+        'className': '_Exception',
+        'reason': 'Exception: MESSAGE',
+        'stackTrace':
+            'main.<fn>#test/raygun4flutter_test.dart 56:30;Declarer.test.<fn>.<fn>#package:test_api/src/backend/declarer.dart 200:19;StackZoneSpecification._registerUnaryCallback.<fn>#package:stack_trace/src/stack_zone_specification.dart',
+        'tags': null,
+        'customData': null,
+      },
+    });
+  });
+
+  test('sendException with tags', () {
+    Raygun.sendException(
+      error: Exception('MESSAGE'),
+      stackTrace: StackTrace.current,
+      tags: ['tag1', 'tag2']
+    );
+    expect(fakeChannel.invocation, {
+      'send': {
+        'className': '_Exception',
+        'reason': 'Exception: MESSAGE',
+        'stackTrace':
+        'main.<fn>#test/raygun4flutter_test.dart 73:30;Declarer.test.<fn>.<fn>#package:test_api/src/backend/declarer.dart 200:19;StackZoneSpecification._registerUnaryCallback.<fn>#package:stack_trace/src/stack_zone_specification.dart',
+        'tags': ['tag1', 'tag2'],
+        'customData': null,
       },
     });
   });
@@ -69,6 +108,24 @@ void main() {
     expect(fakeChannel.invocation, {
       'userId': {
         'userId': null,
+      },
+    });
+  });
+
+  test('Set user with RaygunUserInfo', () {
+    final raygunUserInfo = RaygunUserInfo(
+      identifier: 'ID',
+      firstName: 'FIRST',
+      fullName: 'FULL',
+      email: 'EMAIL',
+    );
+    Raygun.setUser(raygunUserInfo);
+    expect(fakeChannel.invocation, {
+      'user': {
+        'identifier': 'ID',
+        'firstName': 'FIRST',
+        'fullName': 'FULL',
+        'email': 'EMAIL',
       },
     });
   });

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -86,7 +86,7 @@ void main() {
   });
 
   test('Breadcrumb', () {
-    Raygun.breadcrumb('BREADCRUMB');
+    Raygun.recordBreadcrumb('BREADCRUMB');
     expect(fakeChannel.invocation, {
       'breadcrumb': {
         'message': 'BREADCRUMB',

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -88,7 +88,7 @@ void main() {
   test('Breadcrumb', () {
     Raygun.recordBreadcrumb('BREADCRUMB');
     expect(fakeChannel.invocation, {
-      'breadcrumb': {
+      'recordBreadcrumb': {
         'message': 'BREADCRUMB',
       },
     });
@@ -97,7 +97,7 @@ void main() {
   test('UserId with ID', () {
     Raygun.setUserId('ID');
     expect(fakeChannel.invocation, {
-      'userId': {
+      'setUserId': {
         'userId': 'ID',
       },
     });
@@ -106,7 +106,7 @@ void main() {
   test('UserId to null', () {
     Raygun.setUserId(null);
     expect(fakeChannel.invocation, {
-      'userId': {
+      'setUserId': {
         'userId': null,
       },
     });
@@ -121,7 +121,7 @@ void main() {
     );
     Raygun.setUser(raygunUserInfo);
     expect(fakeChannel.invocation, {
-      'user': {
+      'setUser': {
         'identifier': 'ID',
         'firstName': 'FIRST',
         'fullName': 'FULL',


### PR DESCRIPTION
List of changes included: (apply to Android only)

* Change `init()` signature to named parameters and added optional `version`.
* Added `setTags()` and `setCustomData()` methods.
* Added `tags` and `customData` to the error sending methods.
* Error sending methods can generate a stacktrace automatically.
* Added `setUser()` method with `RaygunUserInfo`.
* Added `setVersion()` method.

Still to do:

* Apply API changes to iOS implementation
* Breadcrumbs changes
* setCustomCrashReportingEndpoint method

INCOMPLETE: MERGE INTO `develop` NOT `master` !