### PR TITLE
Update lint rules to fix example failures on generated file

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -7,3 +7,4 @@ linter:
     sort_constructors_first: true
     prefer_single_quotes: true
     public_member_api_docs: true
+    depend_on_referenced_packages: false

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -414,7 +414,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-dev.3"
+    version: "1.0.0"
   shared_preferences:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes linting failures on generated code in example/lib by excluding the depend_on_referenced_packages option

e.g. https://github.com/MindscapeHQ/raygun4flutter/runs/3993980593?check_suite_focus=true

![2021-11-30 14_48_09](https://user-images.githubusercontent.com/161584/143970975-2c0e8267-644d-4267-bf8c-8eb8c6490d6e.png)
