### PR TITLE
Update default endpoint to use api.raygun.com

### DIFF
--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -6,7 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
 class Settings {
-  static const kDefaultCrashReportingEndpoint = "https://api.raygun.io/entries";
+  static const kDefaultCrashReportingEndpoint = "https://api.raygun.com/entries";
 
   static String crashReportingEndpoint = kDefaultCrashReportingEndpoint;
 


### PR DESCRIPTION
We are in the process of moving all primary providers to use api.raygun.com so we want the default endpoint to reflect the preferred location