### PR TITLE
Fix log storage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1
+
+* Fix issue with malformed cached files.
+  * UUID added to cached files to ensure unique filename.
+  * Delete old stored files in case of format exception.
+
 ## 1.2.0
 
 * Upgrade dependencies

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```
 dependencies:
-  raygun4flutter: ^1.2.0
+  raygun4flutter: ^1.2.1
 ```
 
 Alternatively, your editor might support `flutter pub get`. Check the docs for your editor to learn more.

--- a/lib/src/logging/raygun_logger.dart
+++ b/lib/src/logging/raygun_logger.dart
@@ -10,6 +10,8 @@ import 'package:flutter/foundation.dart';
 /// Warnings and Errors are always displayed.
 /// Levels are based on https://github.com/dart-lang/logging/blob/master/lib/src/level.dart
 class RaygunLogger {
+  static bool testMode = false;
+
   static void d(String message) {
     if (kDebugMode) {
       developer.log(
@@ -17,6 +19,9 @@ class RaygunLogger {
         level: 500,
         name: 'raygun4flutter',
       );
+    }
+    if (testMode) {
+      print(message);
     }
   }
 
@@ -26,6 +31,9 @@ class RaygunLogger {
       level: 800,
       name: 'raygun4flutter',
     );
+    if (testMode) {
+      print(message);
+    }
   }
 
   static void w(String message) {
@@ -34,6 +42,9 @@ class RaygunLogger {
       level: 900,
       name: 'raygun4flutter',
     );
+    if (testMode) {
+      print(message);
+    }
   }
 
   static void e(String message) {
@@ -42,5 +53,8 @@ class RaygunLogger {
       level: 1000,
       name: 'raygun4flutter',
     );
+    if (testMode) {
+      print(message);
+    }
   }
 }

--- a/lib/src/services/crash_reporting_device.dart
+++ b/lib/src/services/crash_reporting_device.dart
@@ -62,7 +62,8 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
             RaygunLogger.w('Failed to send ${file.path}');
           }
         } on FormatException catch (e) {
-          RaygunLogger.e('Format exception in stored payload: ${file.path} error: $e');
+          RaygunLogger.e(
+              'Format exception in stored payload: ${file.path} error: $e');
           RaygunLogger.w('Deleting file');
           await file.delete();
         }

--- a/lib/src/services/crash_reporting_device.dart
+++ b/lib/src/services/crash_reporting_device.dart
@@ -63,7 +63,8 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
           }
         } on FormatException catch (e) {
           RaygunLogger.e(
-              'Format exception in stored payload: ${file.path} error: $e');
+            'Format exception in stored payload: ${file.path} error: $e',
+          );
           RaygunLogger.w('Deleting file');
           await file.delete();
         }

--- a/lib/src/services/crash_reporting_device.dart
+++ b/lib/src/services/crash_reporting_device.dart
@@ -7,25 +7,26 @@ import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:raygun4flutter/src/logging/raygun_logger.dart';
 import 'package:raygun4flutter/src/services/crash_reporting_post_service.dart';
+import 'package:uuid/uuid.dart';
 
 import 'settings.dart';
 
 class CrashReportingPostService extends CrashReportingPostServiceBase {
   CrashReportingPostService({http.Client? client}) : super(client: client);
 
+  static const _uuid = Uuid();
+
   @override
   Future<void> store(dynamic jsonPayload) async {
     RaygunLogger.d('Storing crash for later');
     try {
       final cacheDir = await getTemporaryDirectory();
-      RaygunLogger.d('Cache dir: $cacheDir');
-      final cachedFiles = cacheDir
-          .listSync()
-          .where((element) => element.path.endsWith('.raygun4'));
+      final cachedFiles = await _getCachedFiles();
       RaygunLogger.d('Currently ${cachedFiles.length} stored');
       if (cachedFiles.length < Settings.maxReportsStoredOnDevice) {
         final timestamp = DateFormat('yyyyMMddHHmmss').format(DateTime.now());
-        final file = File('${cacheDir.path}/$timestamp.raygun4');
+        final uuid = _uuid.v4();
+        final file = File('${cacheDir.path}/$timestamp-$uuid.raygun4');
         await file.writeAsString(jsonEncode(jsonPayload));
         RaygunLogger.d('Saved payload in: ${file.path}');
       } else {
@@ -47,24 +48,40 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
       return;
     }
     try {
-      final cacheDir = await getTemporaryDirectory();
-      RaygunLogger.d('Cache dir: $cacheDir');
-      final cachedFiles = cacheDir
-          .listSync()
-          .where((element) => element.path.endsWith('.raygun4'));
+      final cachedFiles = await _getCachedFiles();
       RaygunLogger.d('Currently ${cachedFiles.length} stored');
       for (final file in cachedFiles) {
-        final content = await File(file.path).readAsString();
-        final result = await send(apiKey, jsonDecode(content));
-        if (result.isSuccess && result.asSuccess.value != 429) {
-          RaygunLogger.d('Stored payload sent, deleting file: ${file.path}');
+        try {
+          final content = await File(file.path).readAsString();
+          final json = jsonDecode(content);
+          final result = await send(apiKey, json);
+          if (result.isSuccess && result.asSuccess.value != 429) {
+            RaygunLogger.d('Stored payload sent, deleting file: ${file.path}');
+            await file.delete();
+          } else {
+            RaygunLogger.w('Failed to send ${file.path}');
+          }
+        } on FormatException catch (e) {
+          RaygunLogger.e('Format exception in stored payload: ${file.path} error: $e');
+          RaygunLogger.w('Deleting file');
           await file.delete();
-        } else {
-          RaygunLogger.w('Failed to send ${file.path}');
         }
       }
     } catch (e) {
       RaygunLogger.e('Error while sending stored payloads: $e');
+      RaygunLogger.w('Deleting all cached files');
+      final cachedFiles = await _getCachedFiles();
+      for (final file in cachedFiles) {
+        await file.delete();
+      }
     }
+  }
+
+  Future<Iterable<FileSystemEntity>> _getCachedFiles() async {
+    final cacheDir = await getTemporaryDirectory();
+    RaygunLogger.d('Cache dir: $cacheDir');
+    return cacheDir
+        .listSync()
+        .where((element) => element.path.endsWith('.raygun4'));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
-version: 1.2.0
+version: 1.2.1
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter
 


### PR DESCRIPTION
- Append UUID to ensure unique filenames.
- Delete payload when it causes parsing issues.
- Delete all stored payloads on other major sending errors.
- Add tests to cover storage and sending error handling.
