### PR TITLE
chore: Ignore `raygun4flutter` internal dependency in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,4 +32,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # Package in example is accessed by path, 
+      # do not update in pubspec.
+      - dependency-name: "raygun4flutter"
 


### PR DESCRIPTION
This would avoid PRs like https://github.com/MindscapeHQ/raygun4flutter/pull/153