### PR TITLE
feat: #30 add innerError to sendCustom method

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ All arguments but `error` are optional. This method is mainly a convenience wrap
 
 Call `Raygun.sendCustom(className, reason, tags, customData, stackTrace)` to send custom errors to Raygun with your own customised `className` and `reason`. As with `.sendException()`, `tags`, `customData` and `stackTrace` are optional.
 
+You can also provide an optional `innerError` `Exception` object that will be attached to the error report.
+
 For example:
 
 ```dart
@@ -154,6 +156,7 @@ Raygun.sendCustom(
     'custom2': 42,
   },
   stackTrace: StackTrace.current,
+  innerError: Exception('Error!'),
 );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -142,9 +142,10 @@ class _MyAppState extends State<MyApp> {
                     'custom2': 42,
                   },
                   stackTrace: StackTrace.current,
+                  innerError: const MyCustomException('Custom exception'),
                 );
               },
-              child: const Text('Send custom error with tags and customData'),
+              child: const Text('Send custom error with all options'),
             ),
 
             // example: Button tap adds breadcrumb to future error message
@@ -197,5 +198,16 @@ class _MyAppState extends State<MyApp> {
         ),
       ),
     );
+  }
+}
+
+class MyCustomException implements Exception {
+  const MyCustomException(this.message);
+
+  final String message;
+
+  @override
+  String toString() {
+    return 'MyCustomException: $message';
   }
 }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -94,12 +94,16 @@ class Raygun {
   ///
   /// [stackTrace] optional parameter, if not provided this method will obtain
   /// the current stacktrace automatically.
+  ///
+  /// [innerError] optional [Exception] to attach as "innerError"
+  /// in the error report.
   static Future<void> sendCustom({
     required String className,
     required String reason,
     List<String>? tags,
     Map<String, dynamic>? customData,
     StackTrace? stackTrace,
+    Exception? innerError,
   }) async {
     Trace trace;
     if (stackTrace == null) {
@@ -109,7 +113,14 @@ class Raygun {
       trace = Trace.from(stackTrace);
     }
 
-    return CrashReporting.send(className, reason, tags, customData, trace);
+    return CrashReporting.send(
+      className,
+      reason,
+      tags,
+      customData,
+      trace,
+      innerError,
+    );
   }
 
   /// Sets a List of tags which will be sent along with every exception.

--- a/lib/src/messages/raygun_error_message.dart
+++ b/lib/src/messages/raygun_error_message.dart
@@ -10,7 +10,6 @@ class RaygunErrorMessage {
   String message;
   String className;
 
-  // todo: innerError is null at the moment
   RaygunErrorMessage? innerError;
 
   List<RaygunErrorStackTraceLineMessage> stackTrace = [];

--- a/lib/src/messages/raygun_error_message.dart
+++ b/lib/src/messages/raygun_error_message.dart
@@ -33,6 +33,13 @@ class RaygunErrorMessage {
         .toList();
   }
 
+  factory RaygunErrorMessage.fromException(Exception exception) {
+    return RaygunErrorMessage(
+      exception.runtimeType.toString(),
+      exception.toString(),
+    );
+  }
+
   factory RaygunErrorMessage.fromJson(
     Map<String, dynamic> json,
   ) =>

--- a/lib/src/raygun_crash_reporting.dart
+++ b/lib/src/raygun_crash_reporting.dart
@@ -22,8 +22,14 @@ class CrashReporting {
     List<String>? tags,
     Map? customData,
     Trace? trace,
+    Exception? innerError,
   ) async {
-    final RaygunMessage msg = await _buildMessage(className, reason, trace);
+    final RaygunMessage msg = await _buildMessage(
+      className,
+      reason,
+      trace,
+      innerError,
+    );
 
     msg.details.tags = tags ?? [];
     final globalTags = Settings.tags;
@@ -70,12 +76,17 @@ Future<RaygunMessage> _buildMessage(
   String className,
   String reason,
   Trace? trace,
+  Exception? innerError,
 ) async {
   final raygunMessage = RaygunMessage();
 
   raygunMessage.details.error = RaygunErrorMessage(className, reason);
   if (trace != null) {
     raygunMessage.details.error!.setStackTrace(trace);
+  }
+  if (innerError != null) {
+    raygunMessage.details.error!.innerError =
+        RaygunErrorMessage.fromException(innerError);
   }
 
   raygunMessage.details.client = RaygunClientMessage();

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -75,6 +75,24 @@ void main() {
     expect(capturedBody['details']['userCustomData'], {'custom': 42});
   });
 
+  test('sendCustom with innerError', () async {
+    await Raygun.sendCustom(
+      className: 'CLASSNAME',
+      reason: 'REASON',
+      innerError: Exception('MESSAGE'),
+    );
+
+    // main error should be custom className and reason
+    expect(capturedBody['details']['error']['message'], 'REASON');
+    expect(capturedBody['details']['error']['className'], 'CLASSNAME');
+
+    // innerError should be exception message and type
+    expect(capturedBody['details']['error']['innerError']['message'],
+        'Exception: MESSAGE');
+    expect(capturedBody['details']['error']['innerError']['className'],
+        '_Exception');
+  });
+
   test('Breadcrumb', () async {
     Raygun.recordBreadcrumb('BREADCRUMB');
     final breadcrumbMessage = RaygunBreadcrumbMessage(


### PR DESCRIPTION
## Feat: #30 Provide `innerError` to `sendCustom`

### Description :memo:
- **Purpose**: Adds support to the `innerError` property in the error report.
- **Approach**: Adds a new argument to `sendCustom` to pass an `Exception` object.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Updates**

- Add property to `sendCustom` including dart docs.
- Implemented internal logic to add the inner error.
- Add unit test to new argument.

### Screenshots

As the error appears on Raygun:

![image](https://github.com/user-attachments/assets/c5f6fd57-23e1-4aff-a98a-e9f9502db50e)

### Test plan :test_tube:

- Unit and example testing

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)
