### PR TITLE
fix: #29 Package version in client payload

### DIFF
--- a/lib/src/messages/raygun_client_message.dart
+++ b/lib/src/messages/raygun_client_message.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:raygun4flutter/src/services/settings.dart';
 
 part 'raygun_client_message.g.dart';
 
@@ -6,6 +7,7 @@ part 'raygun_client_message.g.dart';
 class RaygunClientMessage {
   String? clientUrl = 'https://github.com/MindscapeHQ/raygun4flutter';
   String? name = 'Raygun4Flutter';
+  String version = Settings.kVersion;
 
   RaygunClientMessage();
 

--- a/lib/src/messages/raygun_client_message.g.dart
+++ b/lib/src/messages/raygun_client_message.g.dart
@@ -9,11 +9,13 @@ part of 'raygun_client_message.dart';
 RaygunClientMessage _$RaygunClientMessageFromJson(Map<String, dynamic> json) =>
     RaygunClientMessage()
       ..clientUrl = json['clientUrl'] as String?
-      ..name = json['name'] as String?;
+      ..name = json['name'] as String?
+      ..version = json['version'] as String;
 
 Map<String, dynamic> _$RaygunClientMessageToJson(
         RaygunClientMessage instance) =>
     <String, dynamic>{
       'clientUrl': instance.clientUrl,
       'name': instance.name,
+      'version': instance.version,
     };

--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -10,6 +10,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
 class Settings {
+  /// The current version of the Raygun4Flutter package.
+  static const kVersion = '3.2.0';
+
   static const kDefaultCrashReportingEndpoint =
       'https://api.raygun.com/entries';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -838,5 +838,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-259.0.dev <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
+# Also update lib/src/services/settings.dart kVersion
 version: 3.2.0
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -55,6 +55,19 @@ void main() {
     expect(capturedBody['details']['userCustomData'], {});
   });
 
+  test('should fill client data', () async {
+    await Raygun.sendException(error: Exception('MESSAGE'));
+    // Client URL and name never change
+    expect(
+      capturedBody['details']['client']['clientUrl'],
+      'https://github.com/MindscapeHQ/raygun4flutter',
+    );
+    expect(capturedBody['details']['client']['name'], 'Raygun4Flutter');
+
+    // Version changes on each release
+    expect(capturedBody['details']['client']['version'], isNotEmpty);
+  });
+
   test('sendException with tags', () async {
     await Raygun.sendException(
       error: Exception('MESSAGE'),


### PR DESCRIPTION
## fix: #29 Package version in client payload

### Description :memo:
- **Purpose**: Adds package version to client payload
- **Approach**: Flutter/Dart doesn't offer a way to obtain this value. The "package version" you can obtain using some plugins is always referring to the app version, and the raygun4flutter version is not accessible. So the solution is to simply have a constant in code, and remind to update it when we do a new release. The comment on the `pubspec.yaml` should help with that.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Add `kVersion` constant to the `Settings` class.
- Add comment in `pubspec.yaml`.
- Add `version` property to the `client` payload.
- Add test to verify `client` payload is generated correctly.

### Test plan :test_tube:

- Unit testing
- TBD: Manual testing

### Author to check :eyeglasses:
- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)