### PR TITLE
fix: catch error in file.delete()

### DIFF
--- a/lib/src/services/crash_reporting_device.dart
+++ b/lib/src/services/crash_reporting_device.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:raygun4flutter/src/logging/raygun_logger.dart';
@@ -20,7 +21,7 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
     RaygunLogger.d('Storing crash for later');
     try {
       final cacheDir = Settings.cacheDirectory ?? await getTemporaryDirectory();
-      final cachedFiles = await _getCachedFiles();
+      final cachedFiles = await getCachedFiles();
       RaygunLogger.d('Currently ${cachedFiles.length} stored');
       if (cachedFiles.length < Settings.maxReportsStoredOnDevice) {
         final timestamp = DateFormat('yyyyMMddHHmmss').format(DateTime.now());
@@ -48,7 +49,7 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
       return;
     }
     try {
-      final cachedFiles = await _getCachedFiles();
+      final cachedFiles = await getCachedFiles();
       RaygunLogger.d('Currently ${cachedFiles.length} stored');
       for (final file in cachedFiles) {
         try {
@@ -73,7 +74,7 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
       RaygunLogger.e('Error while sending stored payloads: $e');
       RaygunLogger.w('Deleting all cached files');
       try {
-        final cachedFiles = await _getCachedFiles();
+        final cachedFiles = await getCachedFiles();
         for (final file in cachedFiles) {
           await file.delete();
         }
@@ -83,11 +84,13 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
     }
   }
 
-  Future<Iterable<FileSystemEntity>> _getCachedFiles() async {
+  @visibleForTesting
+  static Future<Iterable<FileSystemEntity>> getCachedFiles() async {
     final cacheDir = Settings.cacheDirectory ?? await getTemporaryDirectory();
     RaygunLogger.d('Cache dir: $cacheDir');
     return cacheDir
-        .listSync()
-        .where((element) => element.path.endsWith('.raygun4'));
+        .list() // returns a Stream<FileSystemEntity>
+        .where((element) => element.path.endsWith('.raygun4'))
+        .toList(); // convert to Future<List<FileSystemEntity>>
   }
 }

--- a/lib/src/services/crash_reporting_device.dart
+++ b/lib/src/services/crash_reporting_device.dart
@@ -72,9 +72,13 @@ class CrashReportingPostService extends CrashReportingPostServiceBase {
     } catch (e) {
       RaygunLogger.e('Error while sending stored payloads: $e');
       RaygunLogger.w('Deleting all cached files');
-      final cachedFiles = await _getCachedFiles();
-      for (final file in cachedFiles) {
-        await file.delete();
+      try {
+        final cachedFiles = await _getCachedFiles();
+        for (final file in cachedFiles) {
+          await file.delete();
+        }
+      } catch (deleteError) {
+        RaygunLogger.e('Failed to delete cached files: $deleteError');
       }
     }
   }

--- a/test/raygun4flutter_test.dart
+++ b/test/raygun4flutter_test.dart
@@ -178,7 +178,7 @@ void main() {
     await service.store(raygunMessage.toJson());
     await service.store(raygunMessage.toJson());
     await service.store(raygunMessage.toJson());
-    final files = await _getCachedFiles();
+    final files = await CrashReportingPostService.getCachedFiles();
     for (final file in files) {
       print('Found file: ${file.path}');
     }
@@ -206,7 +206,7 @@ void main() {
     final file = File('${cacheDir.path}/error.raygun4');
     await file.writeAsString('asdasdasf{}{}{');
 
-    var files = await _getCachedFiles();
+    var files = await CrashReportingPostService.getCachedFiles();
     expect(files.length, 1);
 
     // should fail with an error
@@ -214,22 +214,15 @@ void main() {
     await service.sendAllStored('KEY');
 
     // should delete all cached files
-    files = await _getCachedFiles();
+    files = await CrashReportingPostService.getCachedFiles();
     expect(files.length, 0);
   });
 }
 
 Future<void> _deleteOldFiles() async {
-  final oldFiles = await _getCachedFiles();
+  final oldFiles = await CrashReportingPostService.getCachedFiles();
   for (final file in oldFiles) {
     print('Deleting old file: ${file.path}');
     await file.delete();
   }
-}
-
-Future<Iterable<FileSystemEntity>> _getCachedFiles() async {
-  final cacheDir = Settings.cacheDirectory!;
-  return cacheDir
-      .listSync()
-      .where((element) => element.path.endsWith('.raygun4'));
 }


### PR DESCRIPTION
## fix: #253 catch error in `file.delete()`

### Description :memo:
- **Purpose**: Fixes an internal provider crash
- **Approach**: Then the provider tries to send stored reports, it will delete them if it fails to send them. Seems that the delete call failed with a "file not found exception", to prevent further errors the code is not surrounded in a try/catch as well.

- Incorporate this fix into the prepared 3.3.0 release in https://github.com/MindscapeHQ/raygun4flutter/pull/250

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Adds try/catch to the delete calls for failed to send files.
- Improved the `getCachedFiles` method by using proper asynchronous access and incorporated in tests.

### Test plan :test_tube:

To test this feature I created a temporal crash report in the `/tmp` folder in Linux, the crash report has a wrong format so that causes an exception, and after capturing the exception the file is deleted.

Besides, I updated tests to cover the `getCachedFiles` method.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)