### PR TITLE
fix: example app fixes for release build testing

### DIFF
--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.raygun4flutter_example"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "25.1.8937393" // Using a specific stable NDK version instead of flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="raygun4flutter_example"
         android:name="${applicationName}"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     // example: init with app version
-    Raygun.init(apiKey: '', version: '1.2.3');
+    Raygun.init(apiKey: '', version: '1.2.4');
 
     // example: set custom tags to all error messages
     Raygun.setTags(['tag1', 'tag2']);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: raygun4flutter_example
 description: Demonstrates how to use the raygun4flutter plugin.
-version: 0.0.1+1
+version: 1.2.4
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.


### PR DESCRIPTION
## Example app fixes for release build testing

### Description :memo:
- **Purpose**: Fix issues discovered while testing the example app in Android release builds (with `--obfuscate`). The app was failing to send crash reports due to missing INTERNET permission in the main AndroidManifest.xml — it was only present in the debug/profile manifests.
- **Approach**: Add the missing permission, update the NDK version to match current dependencies, and set a consistent app version.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: Added `INTERNET` permission to `example/android/app/src/main/AndroidManifest.xml` (was only in debug/profile manifests, causing release builds to fail DNS lookups)
:point_right: Updated NDK version in `build.gradle.kts` from `25.1.8937393` to `27.0.12077973` to resolve plugin compatibility warnings
:point_right: Set example app version to `1.2.4` in both `pubspec.yaml` and `Raygun.init()` call

### Screenshots :camera:
N/A

### Test plan :test_tube:
- Build and run the example app in release mode: `flutter run --release`
- Build with obfuscation: `flutter build apk --release --obfuscate --split-debug-info=debug-info/`
- Verify crash reports are successfully sent to Raygun from release builds
- Verify no build warnings about NDK version

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)