### PR TITLE
chore: reset example app version to 0.0.0+1

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: raygun4flutter_example
 description: Demonstrates how to use the raygun4flutter plugin.
-version: 1.2.4
+version: 0.0.0+1
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.


### PR DESCRIPTION
## [#293]: Reset example app version to 0.0.0+1

### Description :memo:
- **Purpose**: Fixes #293 — PR #292 dropped the `+` build number suffix from the example app version. Flutter apps use `+N` for the Android `versionCode` and iOS `CFBundleVersion`.
- **Approach**: Reset the example app version to `0.0.0+1` to restore the build number suffix and signal that the example app version intentionally does not track the library version.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: Changed `version: 1.2.4` → `version: 0.0.0+1` in `example/pubspec.yaml`

### Screenshots :camera:
N/A

### Test plan :test_tube:
- `flutter pub get` in example/ — resolves successfully
- `flutter analyze` — no issues
- Build example app: `flutter build apk` — confirms valid version format

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)