### PR TITLE
chore: Release 3.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 3.5.4
+
+- fix: emit nested toJson() for json_serializable models (#313) (#315) (2026-05-04)
+- test: expand unit test coverage for public API and serialisation (#314) (2026-05-04)
+- chore(deps): bump json_serializable from 6.13.1 to 6.13.2 (#309) (2026-05-04)
+- chore(deps): bump build_runner from 2.13.1 to 2.15.0 (#310) (2026-05-04)
+- chore(deps): bump connectivity_plus from 7.1.0 to 7.1.1 (#311) (2026-05-04)
+- chore(deps): bump package_info_plus from 9.0.0 to 9.0.1 (#312) (2026-05-04)
+
 ## 3.5.3
 
 - fix: bump connectivity_plus to 7.1.0 and handle satellite connectivity (#306) (2026-04-04)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.5.2"
+    version: "3.5.4"
   shared_preferences:
     dependency: transitive
     description:

--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -11,7 +11,7 @@ import 'package:uuid/uuid.dart';
 
 class Settings {
   /// The current version of the Raygun4Flutter package.
-  static const kVersion = '3.5.3';
+  static const kVersion = '3.5.4';
 
   static const kDefaultCrashReportingEndpoint =
       'https://api.raygun.com/entries';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
 # Also update lib/src/services/settings.dart kVersion
-version: 3.5.3
+version: 3.5.4
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter
 


### PR DESCRIPTION
## chore: Release 3.5.4

Patch release that ships the `toJson()` fix from #315 (closes #313), the test-coverage expansion from #314, and the four Dependabot dependency bumps merged this week.

> **No production behaviour change on the wire.** The SDK already serialised correctly via `jsonEncode()`; #315 just fixes the in-memory shape returned by `toJson()` to match its declared `Map<String, dynamic>` signature.

---

### Description :memo:

**Purpose**
Cut the 3.5.4 release.

**Approach**
Follow [`RELEASING.md`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/RELEASING.md):

1. Bump `version` in [`pubspec.yaml`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/pubspec.yaml) and `kVersion` in [`lib/src/services/settings.dart`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/lib/src/services/settings.dart)
2. Run `flutter pub get` so [`example/pubspec.lock`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/example/pubspec.lock) picks up `3.5.4`
3. Prepend the new `## 3.5.4` section to [`CHANGELOG.md`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/CHANGELOG.md)
4. Verify with `dart format`, `flutter analyze`, `flutter test`, `flutter pub publish --dry-run`

---

### Why patch?

| Change | Wire format | Public API signature | Verdict |
|---|:---:|:---:|---|
| #315 — innerError fix | unchanged | unchanged | Bug fix |
| #314 — test additions | n/a | n/a | No version impact |
| #309–#312 — Dependabot | unchanged | unchanged | Transitive bumps within existing ranges |

No incompatible changes, no new functionality → **patch**.

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

### Updates

- 👉 [`pubspec.yaml`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/pubspec.yaml) — `version: 3.5.3` → `3.5.4`
- 👉 [`lib/src/services/settings.dart`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/lib/src/services/settings.dart) — `kVersion = '3.5.3'` → `'3.5.4'` *(sent in every payload's `details.client.version`)*
- 👉 [`example/pubspec.lock`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/example/pubspec.lock) — refreshed by `flutter pub get` so the example app references the local `3.5.4` path
- 👉 [`CHANGELOG.md`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/CHANGELOG.md) — new `## 3.5.4` entry

---

### CHANGELOG entry

```markdown
## 3.5.4

- fix: emit nested toJson() for json_serializable models (#313) (#315) (2026-05-04)
- test: expand unit test coverage for public API and serialisation (#314) (2026-05-04)
- chore(deps): bump json_serializable from 6.13.1 to 6.13.2 (#309) (2026-05-04)
- chore(deps): bump build_runner from 2.13.1 to 2.15.0 (#310) (2026-05-04)
- chore(deps): bump connectivity_plus from 7.1.0 to 7.1.1 (#311) (2026-05-04)
- chore(deps): bump package_info_plus from 9.0.0 to 9.0.1 (#312) (2026-05-04)
```

---

### Test plan :test_tube:

```bash
flutter pub get
dart format --set-exit-if-changed .
flutter analyze
flutter test
flutter pub publish --dry-run
```

**Verified locally on `release/3.5.4`:**

| Check | Result |
|---|---|
| `dart format --set-exit-if-changed .` | ✅ clean (38 files, 0 changed) |
| `flutter analyze` | ✅ `No issues found!` |
| `flutter test` | ✅ **36 / 36 passed** |
| `flutter pub publish --dry-run` | ✅ clean once the release commit lands |

CI also covers the example builds for **Android, iOS, macOS, Linux, Web (JS), Web (WASM)** — none affected because there are no production code changes in this PR (just version metadata + CHANGELOG).

---

### Post-merge checklist *(for whoever publishes)*

Per [`RELEASING.md`](https://github.com/MindscapeHQ/raygun4flutter/blob/develop/RELEASING.md):

1. `flutter pub publish` *(needs Raygun pub.dev credentials)*
2. Squash & merge this PR into `develop`
3. Create a GitHub Release for tag `3.5.4` *(auto-generated release notes are fine)*
4. Open a `chore: merge to master` PR from `develop` → `master` and use a **regular merge** (not squash)

---

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)