### PR TITLE
chore(ci): harden build and dependency checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
 # Github Actions dependencies updates config
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     commit-message:
@@ -18,6 +19,7 @@ updates:
 # raygun4flutter
   - package-ecosystem: "pub"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     commit-message:
@@ -27,6 +29,7 @@ updates:
 # example app
   - package-ecosystem: "pub"
     directory: "/example"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     commit-message:
@@ -36,4 +39,3 @@ updates:
       # Package in example is accessed by path, 
       # do not update in pubspec.
       - dependency-name: "raygun4flutter"
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6
@@ -20,10 +28,26 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-      - run: flutter pub get
-      - run: dart format --set-exit-if-changed .
-      - run: flutter analyze
-      - run: flutter test
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Verify generated serialization files
+        run: |
+          dart run build_runner build
+          git diff --exit-code -- lib/src/messages
+
+      - name: Analyze project source
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Validate package publishing
+        run: flutter pub publish --dry-run
 
   # Build Android example
   android_example_build:
@@ -34,6 +58,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: flutter build apk --debug
         working-directory: ./example
 
@@ -46,6 +75,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: flutter build ios --no-codesign --debug
         working-directory: ./example
 
@@ -58,6 +92,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: flutter build macos --debug
         working-directory: ./example
 
@@ -70,6 +109,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: |
           sudo apt-get update
           sudo apt-get install ninja-build libgtk-3-dev
@@ -85,6 +129,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: flutter build web --wasm
         working-directory: ./example
 
@@ -97,5 +146,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Install locked dependencies
+        run: flutter pub get --enforce-lockfile
+        working-directory: ./example
+
       - run: flutter build web
         working-directory: ./example

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,11 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,17 @@ All message models use **`json_annotation`** + **`json_serializable`** with code
 - Model files live in `lib/src/messages/` and have a corresponding `.g.dart` file.
 - **Never hand-edit `.g.dart` files.** After changing any model or `@JsonValue`/`@JsonKey` annotation, regenerate with:
   ```
-  dart run build_runner build --delete-conflicting-outputs
+  dart run build_runner build
   ```
 - Enum values sent to the API **must be strings**, not integers. Use `@JsonEnum` to annotate the enum class.
 - The `.g.dart` files **must** be committed — they are not gitignored.
 - Verify serialisation matches the [Raygun API spec](https://raygun.com/documentation/product-guides/crash-reporting/api/) and the Raygun4JS reference implementation.
+
+### Dependency and package validation
+
+- The root package and example app both commit `pubspec.lock` files.
+- CI installs dependencies with `flutter pub get --enforce-lockfile`; dependency or version changes must include matching lockfile updates.
+- CI runs `flutter pub publish --dry-run` to validate package contents.
 
 ### Versioning
 
@@ -67,11 +73,11 @@ See `RELEASING.md` for the full release process. The version appears in **two pl
 
 | Task | Command |
 |---|---|
-| Get dependencies | `flutter pub get` |
+| Get dependencies | `flutter pub get --enforce-lockfile` |
 | Run tests | `flutter test` |
 | Analyse code | `flutter analyze` |
 | Format code | `dart format .` |
-| Regenerate `.g.dart` files | `dart run build_runner build --delete-conflicting-outputs` |
+| Regenerate `.g.dart` files | `dart run build_runner build` |
 | Publish dry-run | `flutter pub publish --dry-run` |
 
 ## Testing approach

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,33 @@ To check the code, run `flutter analyze`.
 
 To format the code, run `dart format .` (note the `.` at the end).
 
+### Dependency and generated file policy
+
+The root package and example app both commit their `pubspec.lock` files. CI
+installs dependencies with `flutter pub get --enforce-lockfile`, so update the
+matching lockfile whenever changing a `pubspec.yaml` or intentionally refreshing
+dependencies.
+
+Dependency updates should usually be isolated to dependency-specific PRs, either
+from Dependabot or from running `flutter pub upgrade` deliberately. Review the
+lockfile diff alongside any manifest change so transitive dependency changes are
+visible.
+
+Message models under `lib/src/messages/` use `json_serializable` and commit their
+generated `.g.dart` files. After changing a model or JSON annotation, regenerate
+the files with:
+
+```
+dart run build_runner build
+```
+
+Before release or when changing package metadata, validate the package contents
+with:
+
+```
+flutter pub publish --dry-run
+```
+
 ### Running from Visual Code
 
 Run the example project directly from VSCode by opening the `example/lib/main.dart`
@@ -70,4 +97,3 @@ Wait for a review by the Raygun team.
 The team will leave you feedback and might ask you to do changes in your code.
 
 Once the PR is approved, the team will merge it.
-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,9 +26,12 @@ where `x.y.z` is the Major, Minor and Patch release numbers.
 Update the `version` in the `pubspec.yaml` file.
 As well, update the `kVersion` in `lib/src/services/settings.dart`.
 
-### Run pub get
+### Update lockfile
 
-Run `flutter pub get` to update the version in the `pubspec.lock`.
+Run `flutter pub get` to update the version in `pubspec.lock`, then keep the
+updated lockfile in the release PR. CI installs dependencies with
+`flutter pub get --enforce-lockfile`, so the release PR must include any
+lockfile changes caused by the version update.
 
 ### Update CHANGELOG.md
 
@@ -42,7 +45,8 @@ git log --pretty=format:"- %s (%as)"
 
 ### Run publish dry-run
 
-Run a publish dry-run to ensure no errors appear:
+Run a publish dry-run from a clean git state to validate the package contents
+before review and before publishing:
 
 ```
 flutter pub publish --dry-run
@@ -102,4 +106,3 @@ Then ask for approval by the Raygun team.
 ### Merge, don't squash
 
 Do not squash this PR, instead, just merge. That will create a merge commit.
-


### PR DESCRIPTION
## chore: harden build and dependency checks

### Description :memo:
- **Purpose**: Harden CI and dependency-management checks after clearing the Dependabot backlog.
- **Approach**: Enforce committed lockfiles in CI installs, add generated serialization drift and package publish dry-run checks, restrict workflow token permissions, cancel redundant CI runs, make Dependabot target `develop` explicitly, and document the dependency/generated-file/release validation policy.

**Type of change**

- [x] This change requires no documentation update

**Updates**

:point_right: CI now runs `flutter pub get --enforce-lockfile` for the root package and each example build job.
:point_right: CI now runs `dart run build_runner build` and fails if `lib/src/messages` generated files drift.
:point_right: CI now runs `flutter pub publish --dry-run` to validate package contents.
:point_right: Workflows now declare least-privilege permissions and the main CI workflow cancels redundant in-progress runs.
:point_right: Dependabot version-update targets are explicitly set to `develop`.
:point_right: `CONTRIBUTING.md`, `RELEASING.md`, and `AGENTS.md` now document the lockfile, generated-file, and publish dry-run expectations.

### Screenshots :camera:
Not applicable.

### Test plan :test_tube:
- python3 YAML parse check for `.github/workflows/main.yml`, `.github/workflows/pr.yml`, and `.github/dependabot.yml`
- `flutter pub get --enforce-lockfile`
- `flutter pub get --enforce-lockfile` from `example/`
- `dart run build_runner build && git diff --exit-code -- lib/src/messages`
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test`
- `flutter build web` from `example/`
- `flutter pub publish --dry-run` from a clean git state
- `git diff --check`

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)