### PR TITLE
chore: release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 3.6.0
+
+- chore(deps): bump package_info_plus, network_info_plus and device_info_plus (#317) (2026-06-03)
+- chore(deps): bump json_annotation from 4.11.0 to 4.12.0 (#318) (2026-06-03)
+- chore(deps): bump json_serializable from 6.13.2 to 6.14.0 (#319) (2026-06-03)
+- chore(deps): refresh dependency lockfiles (#320) (2026-06-09)
+- chore(ci): harden build and dependency checks (#321) (2026-06-09)
+
 ## 3.5.4
 
 - fix: emit nested toJson() for json_serializable models (#313) (#315) (2026-05-04)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -430,7 +430,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.5.4"
+    version: "3.6.0"
   record_use:
     dependency: transitive
     description:

--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -11,7 +11,7 @@ import 'package:uuid/uuid.dart';
 
 class Settings {
   /// The current version of the Raygun4Flutter package.
-  static const kVersion = '3.5.4';
+  static const kVersion = '3.6.0';
 
   static const kDefaultCrashReportingEndpoint =
       'https://api.raygun.com/entries';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
 # Also update lib/src/services/settings.dart kVersion
-version: 3.5.4
+version: 3.6.0
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter
 


### PR DESCRIPTION
## Release: 3.6.0

### Description :memo:
- **Purpose**: Prepare Raygun4Flutter 3.6.0 for publication to pub.dev.
- **Approach**: Update the package version, runtime client version, example lockfile path dependency version, and changelog for the dependency and build-hardening work since 3.5.4.

**Type of change**

- [x] This change requires no documentation update

**Updates**

:point_right: Updates `pubspec.yaml` version to `3.6.0`.
:point_right: Updates `Settings.kVersion` to `3.6.0`.
:point_right: Updates `example/pubspec.lock` path dependency version to `3.6.0`.
:point_right: Adds the `3.6.0` changelog entry.

### Screenshots :camera:
Not applicable.

### Test plan :test_tube:
- `flutter pub get`
- `flutter pub get --enforce-lockfile`
- `dart run build_runner build && git diff --exit-code -- lib/src/messages`
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test`
- `flutter pub get --enforce-lockfile` from `example/`
- `flutter build web` from `example/`
- `flutter pub publish --dry-run` from a clean git state
- `git diff --check`

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)