### PR TITLE
docs: clarify master promotion release step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ See `RELEASING.md` for the full release process. The version appears in **two pl
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (enforced by CI).
 - PR descriptions **must** follow the template in `pull_request_template.md`. Read it before creating a PR and fill in all sections.
 - Release branches are named `release/x.y.z`.
-- PRs merge into `develop`; `develop` is periodically merged to `master`.
+- PRs merge into `develop`; do not merge `develop` to `master` unless the team explicitly requests a `master` promotion.
 
 ### CI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,19 +90,21 @@ GitHub will create a tag for you, you don't need to create the tag manually.
 
 You can also generate the release notes automatically.
 
-## Merge to `master`
+## `master` branch promotion
 
-Once the release process is completed, it would be good to merge `develop` into `master`.
+The normal release process ends after publishing the package, merging the
+release PR into `develop`, and creating the GitHub Release.
 
-### Create a merge PR
+Do not routinely merge `develop` into `master` as part of a release. Only open a
+`develop` to `master` PR when the team explicitly decides that `master` should be
+updated for a specific reason.
 
-Create a PR manually where `develop` merges into `master`
-or by following this link: https://github.com/MindscapeHQ/raygun4flutter/compare/develop...master
+If a `master` promotion is explicitly requested, create a PR manually where
+`develop` merges into `master` or by following this link:
+https://github.com/MindscapeHQ/raygun4flutter/compare/develop...master
 
 You can name the PR `chore: merge to master`.
 
 Then ask for approval by the Raygun team.
 
-### Merge, don't squash
-
-Do not squash this PR, instead, just merge. That will create a merge commit.
+Do not squash this PR. Use a merge commit.


### PR DESCRIPTION
## docs: clarify master promotion release step

### Description :memo:
- **Purpose**: Remove stale release-process guidance that made routine develop-to-master promotion look like part of every release.
- **Approach**: Clarify that the normal release process ends after publishing, merging the release PR to develop, and creating the GitHub Release. Master promotion is now documented as exceptional and only done when explicitly requested.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Updates**

:point_right: Updates RELEASING.md to stop treating develop-to-master merge as a routine release step.
:point_right: Updates AGENTS.md so future agent work follows the same rule.

### Screenshots :camera:
Not applicable.

### Test plan :test_tube:
Documentation-only change. Verified the stale master-promotion wording was removed from the release instructions.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)
