### PR TITLE
chore: Release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.6.1
+
+- fix: restore pub.dev downgrade compatibility (#325) (2026-06-11)
+
 ## 3.6.0
 
 - chore(deps): bump package_info_plus, network_info_plus and device_info_plus (#317) (2026-06-03)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -430,7 +430,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.6.0"
+    version: "3.6.1"
   record_use:
     dependency: transitive
     description:

--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -11,7 +11,7 @@ import 'package:uuid/uuid.dart';
 
 class Settings {
   /// The current version of the Raygun4Flutter package.
-  static const kVersion = '3.6.0';
+  static const kVersion = '3.6.1';
 
   static const kDefaultCrashReportingEndpoint =
       'https://api.raygun.com/entries';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
 # Also update lib/src/services/settings.dart kVersion
-version: 3.6.0
+version: 3.6.1
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter
 


### PR DESCRIPTION
## [Release:] 3.6.1

### Description :memo:
- **Purpose**: Prepare the Raygun4Flutter 3.6.1 patch release so the pub.dev quality score can recover after the dependency lower-bound compatibility fix.
- **Approach**: Bump the package version and client `kVersion` to 3.6.1, update the example lockfile path dependency version, and add the 3.6.1 changelog entry.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: Version bumped from 3.6.0 to 3.6.1.
:point_right: Changelog documents the pub.dev downgrade compatibility fix from #325.
:point_right: Publish dry-run passes with 0 warnings.

### Screenshots :camera:
N/A

### Test plan :test_tube:
- `flutter analyze`
- `flutter test`
- `flutter pub downgrade && flutter analyze`
- `flutter pub get --enforce-lockfile`
- `flutter pub publish --dry-run`

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)