### PR TITLE
chore(deps): refresh dependency lockfiles

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
+      sha256: "0891702f96b2e465fe567b7ec448380e6b1c14f60af552a8536d9f583b6b8442"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
+      sha256: "0891702f96b2e465fe567b7ec448380e6b1c14f60af552a8536d9f583b6b8442"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -300,10 +300,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -484,10 +484,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:


### PR DESCRIPTION
## chore(deps): refresh dependency lockfiles

### Description :memo:
- **Purpose**: Integrate the open Dart dependency updates into both committed lockfiles so the example platform builds validate the same versions as the root package.
- **Approach**: Resolve the reviewed upgrades together under Flutter 3.44.1/Dart 3.12.1 and commit only `pubspec.lock` and `example/pubspec.lock`. This supersedes #328, #329, #330, #331, and #332.

**Type of change**

- [x] Maintenance change (non-breaking dependency lockfile refresh)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Integrated dependency updates

| Superseded PR | Package | Previous version | Dependabot proposal | Integrated version |
|---|---|---:|---:|---:|
| [#328](https://github.com/MindscapeHQ/raygun4flutter/pull/328) | `connectivity_plus` | 7.1.1 | 7.2.0 | **7.3.0** |
| [#329](https://github.com/MindscapeHQ/raygun4flutter/pull/329) | `path_provider` | 2.1.5 | 2.1.6 | **2.1.6** |
| [#330](https://github.com/MindscapeHQ/raygun4flutter/pull/330) | `intl` | 0.20.2 | 0.20.3 | **0.20.3** |
| [#331](https://github.com/MindscapeHQ/raygun4flutter/pull/331) | `device_info_plus` | 13.1.0 | 13.2.0 | **13.2.0** |
| [#332](https://github.com/MindscapeHQ/raygun4flutter/pull/332) | `package_info_plus` | 10.1.0 | 10.2.0 | **10.2.1** |

PRs #328–#332 are closed and superseded by this combined update. `connectivity_plus` 7.3.0 and `package_info_plus` 10.2.1 are deliberate follow-up upgrades to the latest compatible patch/minor releases; they include fixes published after Dependabot opened #328 and #332.

### Screenshots :camera:
Not applicable; lockfile-only maintenance change.

### Test plan :test_tube:

- `flutter pub get --enforce-lockfile`
- `flutter pub get --enforce-lockfile --directory example`
- `dart format --set-exit-if-changed .`
- `dart run build_runner build` plus generated-file diff check
- `flutter analyze`
- `flutter test` — 36 tests passed
- `flutter pub publish --dry-run` — 0 warnings
- `flutter build apk --debug`
- `flutter build linux --debug`
- `flutter build web --wasm`
- `flutter build web`
- GitHub CI to validate iOS and macOS on hosted macOS runners

### Author to check :eyeglasses:
- [x] Project and locally available modules build successfully
- [x] Self-/dev-tested
- [x] Existing unit/integration automation passes
- [x] Code is written to standards
- [x] Documentation is not required for this lockfile-only change

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)