### PR TITLE
chore: Release 3.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 3.6.3
+
+- chore(deps): bump connectivity_plus from 7.3.0 to 7.3.1 (#335) (2026-08-02)
+- chore(deps): bump uuid from 4.5.3 to 4.6.0 (#336) (2026-08-02)
+- chore(deps): bump network_info_plus from 8.1.0 to 8.2.1 (#337) (2026-08-02)
+  - Note: network_info_plus 8.2.x raises Apple platform minimums in SPM manifests.
+
 ## 3.6.2
 
 - chore(deps): bump actions/checkout from 6 to 7 (#327) (2026-07-20)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -430,7 +430,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.6.2"
+    version: "3.6.3"
   record_use:
     dependency: transitive
     description:

--- a/lib/src/services/settings.dart
+++ b/lib/src/services/settings.dart
@@ -11,7 +11,7 @@ import 'package:uuid/uuid.dart';
 
 class Settings {
   /// The current version of the Raygun4Flutter package.
-  static const kVersion = '3.6.2';
+  static const kVersion = '3.6.3';
 
   static const kDefaultCrashReportingEndpoint =
       'https://api.raygun.com/entries';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun4flutter
 description: Raygun4flutter package is the official Raygun crash reporting provider for Flutter.
 # Also update lib/src/services/settings.dart kVersion
-version: 3.6.2
+version: 3.6.3
 homepage: https://raygun.com
 repository: https://github.com/MindscapeHQ/Raygun4Flutter
 


### PR DESCRIPTION
## Summary

Release 3.6.3 — dependency maintenance release. Includes the three Dependabot dependency bumps merged since 3.6.2.

## Changes

- `pubspec.yaml`: version 3.6.2 → 3.6.3
- `lib/src/services/settings.dart`: `kVersion` 3.6.2 → 3.6.3
- `CHANGELOG.md`: new 3.6.3 entry
- `example/pubspec.lock`: version reference updated

## Dependencies bumped in this release

| Dependency | From | To | PR |
|------------|------|----|-----|
| `connectivity_plus` | 7.3.0 | 7.3.1 | #335 |
| `uuid` | 4.5.3 | 4.6.0 | #336 |
| `network_info_plus` | 8.1.0 | 8.2.1 | #337 |

**Note for consumers:** `network_info_plus` 8.2.x raises Apple platform minimums in SPM manifests. This is the only consumer-visible change in this release.

## Verification

- [x] `flutter pub get --enforce-lockfile` — passes
- [x] `flutter analyze` — no issues found
- [x] `flutter test` — 36/36 tests passed
- [x] `flutter pub publish --dry-run` — 0 warnings

## Post-merge

- [ ] Publish to pub.dev (`flutter pub publish`)
- [ ] Squash & merge this PR into `develop`
- [ ] Create GitHub Release with tag `3.6.3` — [releases page](https://github.com/MindscapeHQ/raygun4flutter/releases)
